### PR TITLE
Conditional for policy

### DIFF
--- a/irsa.tf
+++ b/irsa.tf
@@ -7,7 +7,7 @@ module "iam_assumable_role_admin" {
   create_role                   = var.eks ? true : false
   role_name                     = "cert-manager.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks ? aws_iam_policy.cert_manager.0.arn : "" ]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.cert_manager) >= 1 ? aws_iam_policy.cert_manager.0.arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:cert-manager:cert-manager"]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "cluster_domain_name" {
 
 variable "hostzone" {
   description = "In order to solve ACME Challenges certmanager creates DNS records. We should limit the scope to certain hostzone. If star (*) is used certmanager will control all hostzones"
-  type    = list(string)
+  type        = list(string)
 }
 
 # EKS variables


### PR DESCRIPTION
Added and extra condition for the policy in order to avoid the following error:
```
Error: Invalid index

  on .terraform/modules/cert_manager/main.tf line 31, in module "iam_assumable_role_admin":
  31:   role_policy_arns              = [aws_iam_policy.cert_manager.0.arn]
    |----------------
    | aws_iam_policy.cert_manager is empty tuple

The given key does not identify an element in this collection value.
```