### PR TITLE
Deleted dependence_deploy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ module "cert_manager" {
 
   # This module requires helm and OPA already deployed
   dependence_prometheus  = module.prometheus.helm_prometheus_operator_status
-  dependence_deploy      = null_resource.deploy
   dependence_opa         = module.opa.helm_opa_status
 
   # This section is for EKS
@@ -28,7 +27,6 @@ module "cert_manager" {
 | Name                        | Description                                                   | Type     | Default | Required |
 |-----------------------------|---------------------------------------------------------------|:--------:|:-------:|:--------:|
 | dependence_prometheus       | Prometheus Dependence variable                                         | string   |         | yes |
-| dependence_deploy           | Deploy (helm) dependence variable                                      | string   |         | yes |
 | dependence_opa              | Priority class dependence                                              | string   |         | yes |
 | iam_role_nodes              | Nodes IAM role ARN in order to create the KIAM/Kube2IAM                | string   |         | yes |
 | hostzone                    | To solve ACME Challenges. Scope should be limited to hostzone. If star (*) is used certmanager will control all hostzones | string | | yes |

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,6 @@ resource "helm_release" "cert_manager" {
   })]
 
   depends_on = [
-    var.dependence_deploy,
     null_resource.cert_manager_crds,
     var.dependence_prometheus,
     var.dependence_opa,

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "dependence_deploy" {
-  description = "Deploy Module dependence in order to be executed (deploy resource is the helm init)"
-}
-
 variable "dependence_opa" {
   description = "OPA module dependences in order to be executed."
 }


### PR DESCRIPTION
This variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before get installed.

Now we are using Helm 3 and there is not tiller in the clusters.