### PR TITLE
Terraform 0.13 Helm syntax change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,15 +42,10 @@ resource "null_resource" "cert_manager_crds" {
   }
 }
 
-data "helm_repository" "jetstack" {
-  name = "jetstack"
-  url  = "https://charts.jetstack.io"
-}
-
 resource "helm_release" "cert_manager" {
   name          = "cert-manager"
   chart         = "cert-manager"
-  repository    = data.helm_repository.jetstack.metadata[0].name
+  repository    = "https://charts.jetstack.io"
   namespace     = kubernetes_namespace.cert_manager.id
   version       = local.cert-manager-version
   recreate_pods = true


### PR DESCRIPTION
The only Helm resource available from Terraform 0.13.0 onwards is the `helm_release`. This commit removes the deprecated `helm_repository` and replaces the repository value with the correct URL.
https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release