### PR TITLE
Update main.tf to remove deprecated resource.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,15 +42,10 @@ resource "null_resource" "cert_manager_crds" {
   }
 }
 
-data "helm_repository" "jetstack" {
-  name = "jetstack"
-  url  = "https://charts.jetstack.io"
-}
-
 resource "helm_release" "cert_manager" {
   name          = "cert-manager"
   chart         = "cert-manager"
-  repository    = data.helm_repository.jetstack.metadata[0].name
+  repository    = "https://charts.jetstack.io"
   namespace     = kubernetes_namespace.cert_manager.id
   version       = local.cert-manager-version
   recreate_pods = true


### PR DESCRIPTION
We are constantly getting:

```
Warning: This resource is deprecated and will be removed in the next major version. 
Please supply the URL of your repository to helm_release resources directly, using the repository attribute.
See: https://www.terraform.io/docs/providers/helm/r/release.html#example-usage

  on .terraform/modules/cert_manager/main.tf line 45, in data "helm_repository" "jetstack":
  45: data "helm_repository" "jetstack" {

(and 11 more similar warnings elsewhere)
```

This PR aims to fix it setting the repo inline.