### PR TITLE
Upgrade chart to 1.2.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  cert-manager-version = "v0.14.1"
+  cert-manager-version = "v1.2.0"
   crd-path             = "https://github.com/jetstack/cert-manager/releases/download"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -28,20 +28,6 @@ resource "kubernetes_namespace" "cert_manager" {
   }
 }
 
-resource "null_resource" "cert_manager_crds" {
-  provisioner "local-exec" {
-    command = "kubectl apply -n cert-manager --validate=false -f ${local.crd-path}/${local.cert-manager-version}/cert-manager.crds.yaml"
-  }
-  provisioner "local-exec" {
-    when = destroy
-    # destroying the CRDs also deletes all resources of type "certificate" (not the actual certs, those are in secrets of type "tls")
-    command = "exit 0"
-  }
-  triggers = {
-    content = sha1("${local.crd-path}/${local.cert-manager-version}/cert-manager.crds.yaml")
-  }
-}
-
 resource "helm_release" "cert_manager" {
   name          = "cert-manager"
   chart         = "cert-manager"

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,6 @@ resource "helm_release" "cert_manager" {
   })]
 
   depends_on = [
-    null_resource.cert_manager_crds,
     var.dependence_prometheus,
     var.dependence_opa,
   ]

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -5,6 +5,8 @@ ingressShim:
   defaultACMEChallengeType: dns01
   defaultACMEDNS01ChallengeProvider: route53-cloud-platform
 
+installCRDs: true
+
 securityContext:
   enabled: false
 


### PR DESCRIPTION
Current version is v0.14.1 and the suitable version for upgrade is v1.2.0

1.2.0 version changes include:
The stable API version for Certificate is v1. Current certficates in live-1 uses cert-manager.io/v1alpha3 which is still supported and valid.

New installCRDs addition. Set to 'true' so the CRDs installation is managed along with helm chart. And adding CRDs manually using null_resource is not required.

For existing clusters `live-1` and `manager`, the additional labels and annotations needed for the CRDs are added manually.

```
kubectl label crd <cert-manager-crd> app.kubernetes.io/managed-by=Helm
```

```
kubectl patch crd <cert-manager-crd> --type='json' -p='[{"op": "add", "path": "/metadata/annotations", "value":{}},{"op": "add", "path": "/metadata/annotations/meta.helm.sh~1release-namespace", "value":"cert-manager"},{"op": "add", "path": "/metadata/annotations/meta.helm.sh~1release-name", "value":"cert-manager"}]'
```

Reference:
https://cert-manager.io/docs/installation/upgrading/upgrading-0.14-0.15/
https://cert-manager.io/docs/installation/upgrading/upgrading-0.15-0.16/
https://cert-manager.io/docs/installation/upgrading/upgrading-0.16-1.0/
https://cert-manager.io/docs/installation/upgrading/upgrading-1.0-1.1/
https://cert-manager.io/docs/installation/upgrading/upgrading-1.1-1.2/
