### PR TITLE
Add security context with fsgroup for eks

### DIFF
--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -11,9 +11,6 @@ installCRDs: true
 %{ if eks == false ~}
 podAnnotations:
   iam.amazonaws.com/role: "${certmanager_role}"
-
-securityContext:
-  enabled: false
 %{ endif ~}
 
 %{ if eks ~}

--- a/templates/values.yaml.tpl
+++ b/templates/values.yaml.tpl
@@ -7,12 +7,13 @@ ingressShim:
 
 installCRDs: true
 
-securityContext:
-  enabled: false
 
 %{ if eks == false ~}
 podAnnotations:
   iam.amazonaws.com/role: "${certmanager_role}"
+
+securityContext:
+  enabled: false
 %{ endif ~}
 
 %{ if eks ~}
@@ -20,6 +21,10 @@ serviceAccount:
   create: true
   annotations: 
     eks.amazonaws.com/role-arn: "${eks_service_account}"
+
+securityContext:
+  enabled: true
+  fsGroup: 1001
 %{ endif ~}
 
 prometheus:


### PR DESCRIPTION
This is to modify the cert-manager deployment with the correct
filesystem permissions, so the serviceaccount token can be read.

Information related to it:
https://github.com/cert-manager/website/pull/456/