### PR TITLE
Upgrade cert-manager to v1.4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  cert-manager-version = "v1.2.0"
+  cert-manager-version = "v1.4.0"
   crd-path             = "https://github.com/jetstack/cert-manager/releases/download"
 }
 


### PR DESCRIPTION
This release fixes an issue where an ACME `Certificate`, with a long name (52 characters or more)
https://github.com/jetstack/cert-manager/pull/3866.

Ticket related to it:
https://github.com/ministryofjustice/cloud-platform/issues/2976