### PR TITLE
Fix dependency for applying null resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,12 @@ resource "helm_release" "cert_manager" {
   }
 }
 
+resource "time_sleep" "wait_60_seconds" {
+  depends_on = [helm_release.cert_manager]
+
+  create_duration = "60s"
+}
+
 data "template_file" "clusterissuers_staging" {
   template = file("${path.module}/templates/clusterIssuers.yaml.tpl")
   vars = {
@@ -73,7 +79,7 @@ data "template_file" "clusterissuers_production" {
 }
 
 resource "null_resource" "cert_manager_issuers" {
-  depends_on = [helm_release.cert_manager]
+  depends_on = [time_sleep.wait_60_seconds]
 
   provisioner "local-exec" {
     command = "kubectl apply -n cert-manager -f -<<EOF\n${data.template_file.clusterissuers_production.rendered}\nEOF"


### PR DESCRIPTION
helm_release.cert_manager "depends_on" for null resource is not working as expected,
where it is applying null resource cluster issuer before cert-manger.

Use time_sleep to fix the dependency issue.
https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep#delay-create-usage