### PR TITLE
cluster resources not namespaced

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  go-tests:
+    name: Run Terratest Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.14.x
+          terraform_wrapper: false
+
+      - name: Run tf Tests
+        working-directory: .
+        run: |
+          terraform init
+          terraform validate

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -17,7 +17,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Run tf Tests
-        working-directory: .
+        working-directory: test
         run: |
           terraform init
           terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+#  Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# .tfvars files
+*.tfvars
+.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -82,11 +82,11 @@ resource "null_resource" "cert_manager_issuers" {
   depends_on = [time_sleep.wait_60_seconds]
 
   provisioner "local-exec" {
-    command = "kubectl apply -n cert-manager -f -<<EOF\n${data.template_file.clusterissuers_production.rendered}\nEOF"
+    command = "kubectl apply -f -<<EOF\n${data.template_file.clusterissuers_production.rendered}\nEOF"
   }
 
   provisioner "local-exec" {
-    command = "kubectl apply -n cert-manager -f -<<EOF\n${data.template_file.clusterissuers_staging.rendered}\nEOF"
+    command = "kubectl apply -f -<<EOF\n${data.template_file.clusterissuers_staging.rendered}\nEOF"
   }
 
   provisioner "local-exec" {
@@ -112,7 +112,7 @@ resource "null_resource" "cert_manager_monitoring" {
 
   provisioner "local-exec" {
     when    = destroy
-    command = "kubectl delete -n cert-manager -f ${path.module}/resources/monitoring/alerts.yaml"
+    command = "kubectl delete -f ${path.module}/resources/monitoring/alerts.yaml"
   }
 
   triggers = {

--- a/test/cert-manager.tf
+++ b/test/cert-manager.tf
@@ -1,0 +1,13 @@
+module "cert_manager" {
+  source = "../"
+  # "github.com/ministryofjustice/cloud-platform-terraform-certmanager?ref=1.2.1"
+
+  iam_role_nodes      = "arn:aws:iam::000000000000:node"
+  cluster_domain_name = "cert-manager.cloud-platform.service.justice.gov.uk"
+  hostzone            = "AAATEST"
+
+  dependence_prometheus = "ignore"
+  dependence_opa        = "ignore"
+
+  eks = false
+}

--- a/test/cert-manager.tf
+++ b/test/cert-manager.tf
@@ -4,7 +4,7 @@ module "cert_manager" {
 
   iam_role_nodes      = "arn:aws:iam::000000000000:node"
   cluster_domain_name = "cert-manager.cloud-platform.service.justice.gov.uk"
-  hostzone            = "AAATEST"
+  hostzone            = ["AAATEST"]
 
   dependence_prometheus = "ignore"
   dependence_opa        = "ignore"

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,17 @@
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+# To be use in case the resources need to be created in London
+provider "aws" {
+  alias  = "london"
+  region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias  = "ireland"
+  region = "eu-west-1"
+}
+

--- a/test/versions.tf
+++ b/test/versions.tf
@@ -1,0 +1,12 @@
+
+terraform {
+  required_version = ">= 0.14"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
otherwise we get 
Error: Error running command 'kubectl -n cert-manager delete ClusterIssuer letsencrypt-staging letsencrypt-production': exit status 1. Output: warning: deleting cluster-scoped resources, not scoped to the provided namespace 
in 1.19