### PR TITLE
Upgrade cert-manger to version "v1.5.3"

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "helm_release" "cert_manager" {
   chart         = "cert-manager"
   repository    = "https://charts.jetstack.io"
   namespace     = kubernetes_namespace.cert_manager.id
-  version       = "v1.4.0"
+  version       = "v1.5.3"
   recreate_pods = true
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {


### PR DESCRIPTION
This is to keep cert-manager up to date, also fix Certificate sometimes fails to issue properly.

Related to:
https://github.com/ministryofjustice/cloud-platform/issues/3113