### PR TITLE
update-pin-helm-version-in-modules

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,7 @@ terraform {
     }
     helm = {
       source = "hashicorp/helm"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
Why: 
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)