### PR TITLE
Fix hashicorp/helm version pinning constraints

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -5,7 +5,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.6.0"
+      version = ">= 2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
This version constraint (`~>`) currently causes an issue when upgrading the `hashicorp/helm` provider in cloud-platform-infrastructure (see [build](https://concourse.cloud-platform.service.justice.gov.uk/builds/3262451)).