### PR TITLE
Removing wait from certmanager build

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,11 +39,11 @@ resource "helm_release" "cert_manager" {
   }
 }
 
-resource "time_sleep" "wait_60_seconds" {
-  depends_on = [helm_release.cert_manager]
+# resource "time_sleep" "wait_60_seconds" {
+#   depends_on = [helm_release.cert_manager]
 
-  create_duration = "60s"
-}
+#   create_duration = "60s"
+# }
 
 data "template_file" "clusterissuers_staging" {
   template = file("${path.module}/templates/clusterIssuers.yaml.tpl")

--- a/main.tf
+++ b/main.tf
@@ -39,12 +39,6 @@ resource "helm_release" "cert_manager" {
   }
 }
 
-# resource "time_sleep" "wait_60_seconds" {
-#   depends_on = [helm_release.cert_manager]
-
-#   create_duration = "60s"
-# }
-
 data "template_file" "clusterissuers_staging" {
   template = file("${path.module}/templates/clusterIssuers.yaml.tpl")
   vars = {


### PR DESCRIPTION
Removing the 60 second wait from the build for cert manager due to the separation of core and components. [#5886](https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=71051417)

This change has been tested using a test cluster and no issues seen when building core and components. 
The change should reduce cluster build times by 1 minute as certmanager is the last component to finish building at the core level. 