### PR TITLE
ci: add dependabot and dependency project workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/dependencies-project.yml
+++ b/.github/workflows/dependencies-project.yml
@@ -1,0 +1,11 @@
+name: Add dependencies to Cloud Platform project
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  add-dependabot-to-project:
+    uses: ministryofjustice/cloud-platform-github-workflows/.github/workflows/dependencies-project.yml@main
+    secrets: inherit


### PR DESCRIPTION
## 👀 Purpose

- Add dependabot
- Add dependency project workflow [#6297](https://github.com/ministryofjustice/cloud-platform/issues/6297)