### PR TITLE
Bump cert manager to 1.17.4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "helm_release" "cert_manager" {
   chart         = "cert-manager"
   repository    = "https://charts.jetstack.io"
   namespace     = kubernetes_namespace.cert_manager.id
-  version       = "v1.15.5"
+  version       = "v1.17.4"
   recreate_pods = true
 
   values = [templatefile("${path.module}/templates/values.yaml.tpl", {

--- a/templates/clusterIssuers.yaml.tpl
+++ b/templates/clusterIssuers.yaml.tpl
@@ -17,6 +17,4 @@ spec:
       dns01:
         cnameStrategy: "Follow"
         # Here we define a list of DNS-01 providers that can solve DNS challenges
-        route53:
-          region: eu-west-2
-
+        route53: {} 


### PR DESCRIPTION
- bump cert manager to `1.17.4`
- remove region spec from issuer
- relates to https://github.com/ministryofjustice/cloud-platform/issues/7420